### PR TITLE
Add hedwig_simple_responders to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 ## Responders
 * [Mopidy](https://github.com/trestrantham/hedwig_mopidy) - Responder for Mopidy
+* [Simple Responders](https://github.com/trestrantham/hedwig_mopidy) - A collection of simple Responders inspired by [hubot-scripts](https://github.com/github/hubot-scripts)
 
 ## Resources
 #### Blog Posts

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Responders
 * [Mopidy](https://github.com/trestrantham/hedwig_mopidy) - Responder for Mopidy
-* [Simple Responders](https://github.com/trestrantham/hedwig_mopidy) - A collection of simple Responders inspired by [hubot-scripts](https://github.com/github/hubot-scripts)
+* [Simple Responders](https://github.com/labzero/hedwig_simple_responders) - A collection of simple Responders inspired by [hubot-scripts](https://github.com/github/hubot-scripts)
 
 ## Resources
 #### Blog Posts


### PR DESCRIPTION
We just published an initial collection of simple Responders for Hedwig based off of Hubot's `hubot-scripts` package. There are currently 13 Responders in the collection but we are porting more and more each day